### PR TITLE
Makefile.am: fix placement of MBTOOLS_LIBS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,7 @@ AM_CFLAGS = ${my_CFLAGS} \
 	-ffunction-sections \
 	-fdata-sections
 
-AM_LDFLAGS = ${MBTOOLS_LIBS} \
+AM_LDFLAGS = \
 	-Wl,--gc-sections \
 	-Wl,--as-needed
 
@@ -28,5 +28,9 @@ mbcollect_SOURCES = \
 	output.c \
 	collect.c
 
+mbcollect_LDADD = ${MBTOOLS_LIBS}
+
 mbrecorder_SOURCES = \
 	recorder.c
+
+mbrecorder_LDADD = ${MBTOOLS_LIBS}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,7 +9,7 @@ AM_CFLAGS = ${my_CFLAGS} \
     -ffunction-sections \
     -fdata-sections
 
-AM_LDFLAGS = ${MBTOOLS_LIBS} \
+AM_LDFLAGS = \
     -Wl,--gc-sections \
     -Wl,--as-needed
 
@@ -20,3 +20,5 @@ noinst_PROGRAMS = \
 unit_test_server_SOURCES = unit-test-server.c
 unit_test_client_SOURCES = unit-test-client.c
 
+unit_test_server_LDADD = ${MBTOOLS_LIBS} 
+unit_test_client_LDADD = ${MBTOOLS_LIBS} 


### PR DESCRIPTION
LIBS need to be at the end of the linker line; placing them in LDFLAGS
puts them in the wrong order, resulting in diagnostics as documented in
issue #4.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>